### PR TITLE
fix: add submodules option to checkout in build-pdf workflow

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          submodules: true
       
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3.0.0


### PR DESCRIPTION
## Summary
- checkout時にsubmodulesオプションを追加
- これにより`themes/cayman-hugo-theme`がCI環境で正しく取得され、PDFが正常に生成される

## 原因
`actions/checkout`はデフォルトでsubmoduleを取得しないため、テーマが見つからずHugoのビルドが失敗していた

🤖 Generated with [Claude Code](https://claude.com/claude-code)