### PR TITLE
fix: add Japanese fonts and fix baseURL for PDF generation

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -26,13 +26,14 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
+      - name: Install Japanese fonts
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y fonts-noto-cjk
+
       - name: Build PDF
         run: |
-          # Install dependencies for chromedp if needed, but usually ubuntu-latest has chrome
-          # We might need to install chrome explicitly or use a container, but let's try default first.
-          # Actually, chromedp usually finds the installed chrome.
-          # However, in CI environments, we might need to install google-chrome-stable.
-          make build
+          hugo -c docs -b http://localhost:8080/
           make pdf
 
       - name: Create Release and Upload PDF


### PR DESCRIPTION
## Summary
- CI環境に日本語フォント（fonts-noto-cjk）をインストール
- PDF生成時のbaseURLを`http://localhost:8080/`に上書き

## 原因
1. CI環境（Ubuntu）に日本語フォントがなく、日本語が表示されなかった
2. `baseURL`が`https://resume.tjun.org`だったため、CSSのパスが絶対URLになり、ローカルサーバーからPDF生成時にCSSが読み込めなかった

🤖 Generated with [Claude Code](https://claude.com/claude-code)