### PR TITLE
fix: add submodules to workflows and remove footer text

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          submodules: true
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          submodules: true
       
       - name: Setup Node.js
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0

--- a/config.toml
+++ b/config.toml
@@ -30,7 +30,7 @@ theme = "cayman-hugo-theme"
   dateFormat = "2006-01-02"
 
   # Footer text, can be markdown
-  footer = "Made with [Hugo](https://gohugo.io/). Themed by [Cayman](https://github.com/zwbetz-gh/cayman-hugo-theme). Deployed to Cloudflare Pages."
+  footer = ""
 
   # If true, the CSS/JS for Katex math typesetting are enabled
   katex = true


### PR DESCRIPTION
## Summary
- test.ymlとpublish-cloudflare.ymlのcheckoutにsubmodulesオプションを追加
- config.tomlのfooterテキストを削除

## 変更内容
1. **submodules追加**: テーマがsubmoduleとして管理されているため、checkout時に取得が必要
2. **footer削除**: PDFのフッターに表示されていた「Made with Hugo...」を削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)