### PR TITLE
feat: add Renovate configuration for automated dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "schedule": ["before 9am on the first day of the month"],
+  "timezone": "Asia/Tokyo",
+  "minimumReleaseAge": "7 days",
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "packageRules": [
+    {
+      "matchManagers": ["npm", "gomod", "github-actions"],
+      "groupName": "all dependencies",
+      "groupSlug": "all-deps"
+    }
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 9am on the first day of the month"]
+  }
+}


### PR DESCRIPTION
## Summary
- Renovateの設定を追加し、依存関係の自動更新を有効化
- 対象: npm (package.json/yarn.lock), Go modules (go.mod), GitHub Actions workflows
- 月1回（毎月1日）の更新スケジュール

## 設定内容
- リリースから7日経過したパッケージのみ対象（`minimumReleaseAge: 7 days`）
- 更新は月1回、毎月1日の朝9時前（JST）に実行
- 全ての依存関係を1つのPRにグループ化

## 次のステップ
このPRをマージ後、[Renovate GitHub App](https://github.com/apps/renovate) をリポジトリにインストールしてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)